### PR TITLE
Fixed windows compatibility

### DIFF
--- a/shrink_it.py
+++ b/shrink_it.py
@@ -110,7 +110,7 @@ if os.path.isdir(rom_file) :
   ## call this script for each file
   for x in os.listdir(rom_file) :
     if x.endswith(".zip") or x.endswith(".7z"):
-      os.system(sys.executable +" "+ sys.argv[0] + ' ' + os.path.join(rom_path, str(x)))
+      subprocess.run([sys.executable, sys.argv[0], os.path.join(rom_path, str(x))])
   exit()
 
 printProgressBar(0, 1, prefix = rom_name.ljust(25), suffix = 'Unzip')


### PR DESCRIPTION
It was failing when trying to fork itself because python, by default, is installed in a path with spaces and it breaks with os.system.

Changed: Replaced os.system() by subprocess.run()

This fixes running on Windows 10 natively (no WSL).
